### PR TITLE
Swap layout: Fall back to next layout

### DIFF
--- a/a4.c
+++ b/a4.c
@@ -1007,7 +1007,7 @@ static void layout(char *args[]) {
 		if (pertag.lastlayout[pertag.curtag])
 			layoutname = pertag.lastlayout[pertag.curtag];
 		else
-			return;
+			layoutname = "+1";
 	}
 
 	pertag.lastlayout[pertag.curtag] = currlayout->name;


### PR DESCRIPTION
### Pick the next layout (as fallback) when the user performs `layout swap` but a last layout is not yet defined

When I start a new `a4` session and try to toggle/swap the layout (`layout swap`/`C-a Tab`) before I have switched the layout explicitly (for example via `layout fullscreen`/`C-a f`), nothing happens. While `a4` can't know which layout I actually wanted to switch to, it's certain that I wanted to get a different layout.

With this pull request, the next layout (`layout +1`) gets activated as a fallback.

(Personally, I would prefer to set the fullscreen layout in such a case. But this would be a bad choice if the user has removed the fullscreen layout in the a4 config file.)

@rpmohn : Just decline if you don't like such a behavior. Then at least other users will find this patch when they search for it.