### PR TITLE
New actions: view next|prev

### DIFF
--- a/a4.1
+++ b/a4.1
@@ -108,6 +108,12 @@ View all terminal windows of all tags.
 .B Ctrl\-g v Tab
 Switch to viewing the terminal windows of the previously selected set of tags.
 .TP
+.B Ctrl\-PageDown
+View terminal windows of the next tag(s) to the right.
+.TP
+.B Ctrl\-PageUp
+View terminal windows of the next tag(s) to the left.
+.TP
 .B Ctrl\-g t 0
 Set all tags on the focused terminal window.
 .TP
@@ -503,7 +509,7 @@ section,
 .B tagtoggle
 may be used without a parameter to toggle the clicked tag on the selected window.
 .TP
-.BR view " [<" "tag name" >| _all | _swap ]
+.BR view " [<" "tag name" >| _all | _swap | next | prev ]
 View all terminal windows with the
 .B tag name
 tag enabled.
@@ -513,6 +519,12 @@ views all windows of all tags.
 Special parameter
 .B _swap
 views the windows of whichever set of tags were previously selected.
+Special parameter
+.B next
+views all windows of the next tag(s) to the right.
+Special parameter
+.B prev
+views all windows of the next tag(s) to the left.
 If mapped in the
 .B MouseTagNamesActions
 section,

--- a/a4.c
+++ b/a4.c
@@ -259,6 +259,7 @@ static void focusnextvis(void);
 static void vscroll_delta(TFrame *tframe, int delta);
 static unsigned int bitoftag(const char *tag);
 static void tagschanged(void);
+static void viewnext(bool backwards);
 static void viewswap(void);
 static void viewset(char *tagname);
 
@@ -1329,6 +1330,27 @@ static void tagtoggle(char *args[]) {
 	}
 }
 
+static void viewnext(bool backwards) {
+	if (tagset[seltags] == TAGMASK || tagset[seltags] == 0)
+		return;
+	unsigned int newtagset = tagset[seltags];
+	if (backwards)
+		newtagset = (newtagset >> 1) | (newtagset << (config.ntags - 1));
+	else
+		newtagset = (newtagset << 1) | (newtagset >> (config.ntags - 1));
+	if (newtagset && tagset[seltags] != newtagset) {
+		if(!(newtagset & 1 << (pertag.curtag - 1))) {
+			pertag.prevtag = pertag.curtag;
+			int i;
+			for (i=0; !(newtagset &1 << i); i++) ;
+			pertag.curtag = i + 1;
+		}
+		set_pertag();
+		tagset[seltags] = newtagset;
+		tagschanged();
+	}
+}
+
 static void viewswap(void) {
 	seltags ^= 1;
 	unsigned int tmptag = pertag.prevtag;
@@ -1363,6 +1385,10 @@ static void view(char *args[]) {
 		viewset(NULL);
 	else if (ARGS0EQ("_swap"))             /* special arg "_swap" */
 		viewswap();
+	else if (ARGS0EQ("next"))              /* special arg "next" */
+		viewnext(false);
+	else if (ARGS0EQ("prev"))              /* special arg "prev" */
+		viewnext(true);
 	else
 		viewset(args[0]);
 }

--- a/etc/a4.ini
+++ b/etc/a4.ini
@@ -97,6 +97,8 @@ C-g t #         = tag #
 C-g V #         = viewtoggle #
 C-g T #         = tagtoggle #
 
+C-PageUp        = view prev
+C-PageDown      = view next
 C-g v 0         = view _all
 C-g v Tab       = view _swap
 C-g t 0         = tag _all


### PR DESCRIPTION
Add actions to view the next tag(s) to the right or the left side. Bind them to C-PageUp/PageDown, by default.

Examples:
* If tag 1 is selected, `view next` shows all windows on tag 2 (same as `view 2`).
* If tag 2 is selected, `view next` shows all windows on tag 3 (same as `view 3`).
* If the last tag is selected, `view next` shows all windows on tag 1 (same as `view 1`).
* If tags 2 and 4 are selected, `view next` shows all windows on tags 3 and 5 (same as `view 3` + `viewtoggle 5`).
* Analogous for `view prev`: If tag 2 is selected,  `view prev` shows all windows on tag 1 (same as `view 1`).