### PR TITLE
New action: create nextfree

### DIFF
--- a/a4.1
+++ b/a4.1
@@ -62,6 +62,9 @@ below).
 .B Ctrl\-g c
 Create a new terminal window.
 .TP
+.B Ctrl\-g n
+Create a new terminal window on the left-most unused tag.
+.TP
 .B Ctrl\-g x x
 Force close the focused terminal.
 .TP
@@ -369,8 +372,10 @@ refers to all windows in the
 .BR "focus group" .
 .SS Actions that can be mapped to keyboard and mouse events
 .TP
-.B create
-Create a new terminal window and is assigned the currently selected tags. The new window is placed in the #1 position in the order of all visible windows.
+.B create [ nextfree ]
+Create a new terminal window and is assigned the currently selected tags. The new window is placed in the #1 position in the order of all visible windows. If the parameter
+.BR nextfree
+is used, the new window is assigned the first available unused tag.
 .TP
 .B destroy
 Force close the selected or mouse-selected terminal (not all focused or mouse-focused terminals).

--- a/a4.c
+++ b/a4.c
@@ -1655,6 +1655,17 @@ static void noaction(char *args[]) {
 }
 
 static void create(char *args[]) {
+	if (args && args[0] && ARGS0EQ("nextfree")) {  /* special arg "nextfree" */
+		// show first unused tag
+		unsigned int occupied = 0;
+		for (TFrame *tframe = tframes; tframe; tframe = tframe->next) {
+			occupied |= tframe->tags;
+		}
+		unsigned int i;
+		for (i = 0; i < config.ntags && (occupied & (1 << i)); i++);
+		if (i < config.ntags)
+			viewset(config.tagnames[i]);
+	}
 	create_tframe();
 	arrange();
 }

--- a/etc/a4.ini
+++ b/etc/a4.ini
@@ -77,6 +77,7 @@ zoom_bottom     = " ├┴┤ "
 # in the order of M-C-S-. Two special keys that must be fully spelled out are
 # "Space" and "Hyphen".
 C-g c           = create
+C-g n           = create nextfree
 C-g x x         = destroy
 C-g Enter       = zoom
 C-g .           = minimize


### PR DESCRIPTION
Add action to create a window on the first available unused tag. Bind it to C-g n, by default.

Example:

Three windows are assigned to tag 1, one window is assigned to tag 2. Tag 1 is selected. `C-g n` creates a new window and assigns it to tag 3. (Same effect as using this key combo: `C-g v 3` `C-g c`, but shorter.)